### PR TITLE
fix: add open graph meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@decentraland" />
     <meta name="twitter:creator" content="@decentraland" />
-    <meta property="og:url" content="%PUBLIC_URL%/" />
+    <meta property="og:url" content="https://play.decentraland.org/" />
     <meta property="og:title" content="Decentraland" />
     <meta property="og:description" content="Decentraland is a virtual social platform built and governed by its users. Every day, users enter the world to meet up, play games, attend live events, trade in the marketplace, engage with brands, visit galleries and much more" />
     <meta property="og:image" content="%PUBLIC_URL%/images/background-v3@1x.jpg" />

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,13 @@
     <link rel="preload" href="%PUBLIC_URL%/images/background-v3@2x.jpg" as="image" />
     <link rel="preload" href="%PUBLIC_URL%/images/loading.gif" as="image" />
     <title>Decentraland</title>
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@decentraland" />
+    <meta name="twitter:creator" content="@decentraland" />
+    <meta property="og:url" content="%PUBLIC_URL%/" />
+    <meta property="og:title" content="Decentraland" />
+    <meta property="og:description" content="Decentraland is a virtual social platform built and governed by its users. Every day, users enter the world to meet up, play games, attend live events, trade in the marketplace, engage with brands, visit galleries and much more" />
+    <meta property="og:image" content="%PUBLIC_URL%/images/background-v3@1x.jpg" />
     <style type="text/css">
       html,
       body {


### PR DESCRIPTION
This PR solves #146 by adding open graph meta tags

Twitter:

<img width="563" alt="Screen Shot 2022-01-19 at 18 20 06" src="https://user-images.githubusercontent.com/208789/150215752-f93bbc05-13e8-4551-82d3-6d1419999eac.png">

Facebook:

<img width="731" alt="Screen Shot 2022-01-19 at 18 19 58" src="https://user-images.githubusercontent.com/208789/150215774-34c51685-3226-431b-ba66-6c30367c481f.png">


### how to test:

Just copy and pate the url on the following official validators:

[https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)

[https://developers.facebook.com/tools/debug/](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fexplorer-artifacts.decentraland.org%2F%40dcl%2Fexplorer-website%2Fbranch%2Ffix%2Fopen-graph%2F%3Fkernel-branch%3Dmain%26renderer-branch%3Dmaster)

or send the build url using any message app that send previews