### PR TITLE
chore: Remove Wallet Connect data on init

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { initializeBrowserRecommendation } from './integration/browser'
 import App from './components/App'
 import { initializeDesktopApp } from './integration/desktop'
 import { initializeFeatureFlags } from './integration/featureFlags'
+import { clearWalletConnect } from './utils/clearWalletConnect'
 
 configureSegment()
 configureRollbar()
@@ -25,5 +26,6 @@ ReactDOM.render(
     initializeBrowserRecommendation()
     initializeFeatureFlags()
     initializeDesktopApp()
+    clearWalletConnect()
   }
 )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,6 @@ ReactDOM.render(
     initializeBrowserRecommendation()
     initializeFeatureFlags()
     initializeDesktopApp()
-    clearWalletConnect()
+    clearWalletConnect() // Remove WC data stored in local storage to prevent auto connect
   }
 )

--- a/src/utils/clearWalletConnect.ts
+++ b/src/utils/clearWalletConnect.ts
@@ -1,0 +1,24 @@
+import { ProviderType } from '@dcl/schemas'
+
+const DCL_CONNECT_STORAGE_KEY = 'decentraland-connect-storage-key'
+const WC_STORAGE_KEY = 'walletconnect'
+
+export function clearWalletConnect() {
+  try {
+    // Remove data created and stored by wallet connect which tracks the wallet that has connected before
+    localStorage.removeItem(WC_STORAGE_KEY)
+
+    // Remove dcl connect stored data only if the provider is wallet connect
+    const connectData = localStorage.getItem(DCL_CONNECT_STORAGE_KEY)
+
+    if (connectData) {
+      const json = JSON.parse(connectData)
+
+      if (json.providerType === ProviderType.WALLET_CONNECT) {
+        localStorage.removeItem(DCL_CONNECT_STORAGE_KEY)
+      }
+    }
+  } catch (e) {
+    // Failed to clear data
+  }
+}

--- a/src/utils/clearWalletConnect.ts
+++ b/src/utils/clearWalletConnect.ts
@@ -5,10 +5,13 @@ const WC_STORAGE_KEY = 'walletconnect'
 
 export function clearWalletConnect() {
   try {
-    // Remove data created and stored by wallet connect which tracks the wallet that has connected before
+    // Remove data created and stored by wallet connect which tracks the wallet that has connected before.
+    // Removing this will show the QR code to connect even if the user has the wallet already connected.
     localStorage.removeItem(WC_STORAGE_KEY)
 
-    // Remove dcl connect stored data only if the provider is wallet connect
+    // Remove dcl connect stored data only if the provider is wallet connect.
+    // Removing this will prevent showing the QR code automatically on init if the user connected to the app
+    // with wallet connect previously.
     const connectData = localStorage.getItem(DCL_CONNECT_STORAGE_KEY)
 
     if (connectData) {


### PR DESCRIPTION
In order to prevent wallet connect from trying to reconnect each time the user enters the application, both the `walletconnect` and `decentraland-connect-storage-key` (when provider type is wallet_connect) are being removed from local storage.

Removing `walletconnect` will prevent the app to bypass the QR when the user is already connected with the wallet.
Removing `decentraland-connect-storage-key` will prevent the QR to be automatically shown when the user enters the app again.