### PR TITLE
chore: update decentraland-ecs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1727,28 +1727,33 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/amd": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/@dcl/amd/-/amd-6.6.8.tgz",
-      "integrity": "sha512-BWlOD9vonsnSn9/d9QQCYZ83crjrZAbPP9jWbWMaJL8tVwnmhsbxaKK6fn2ryp0aCq6x8c6k7HwNrFodysu4mg=="
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@dcl/amd/-/amd-6.10.0.tgz",
+      "integrity": "sha512-erdqX+HKYACyzLdCbdsB6RsIXtdQ/SX22yLQfVWmexhDhuJfFxaCscYe3PfD1dp2IXF1tIdOpKdu4zJnj2bHBg=="
     },
     "@dcl/build-ecs": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/@dcl/build-ecs/-/build-ecs-6.6.8.tgz",
-      "integrity": "sha512-/OqiI3z3i5OuzGe/Ca1/vdbVkhdNYCGnMQ2pNZ8dZv+MZe9BnLWm+/jwPjZLC1uWDbznip/HgAUd64eiOQPTQA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@dcl/build-ecs/-/build-ecs-6.10.0.tgz",
+      "integrity": "sha512-y9/+fCAIPxbUPpqvNLX3udrfbCVndyd+nzEpodp7ulhPzLR+jJF38XaWwjU0rNelNdlp+P0MmceYMCSGEeEMpw==",
       "requires": {
         "terser": "^5.7.2",
         "typescript": "^4.4.2"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         },
         "source-map-support": {
-          "version": "0.5.20",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-          "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -1762,19 +1767,20 @@
           }
         },
         "terser": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-          "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+          "version": "5.12.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
+          "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
           "requires": {
+            "acorn": "^8.5.0",
             "commander": "^2.20.0",
             "source-map": "~0.7.2",
             "source-map-support": "~0.5.20"
           }
         },
         "typescript": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-          "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+          "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
         }
       }
     },
@@ -1784,9 +1790,9 @@
       "integrity": "sha512-ucbcOWaGd5MneveJO+fUDG3GZrfNt1puCrT7GxwSwF1a7ZuRkcO2tzogBAZe53etbKIFg/kzMJ7jV1PlKgm3ug=="
     },
     "@dcl/kernel": {
-      "version": "1.0.0-1217331229.commit-f70a80e",
-      "resolved": "https://registry.npmjs.org/@dcl/kernel/-/kernel-1.0.0-1217331229.commit-f70a80e.tgz",
-      "integrity": "sha512-ZqBoA1grCIROjCjl6qMzKNcIq4C6RK0xbjzx9IhwJwhUqAK1+ay/eyiNt2AaI8RQC4XjbP2vdh4AqE8dYQ5tfQ=="
+      "version": "1.0.0-2071407489.commit-9b51f8e",
+      "resolved": "https://registry.npmjs.org/@dcl/kernel/-/kernel-1.0.0-2071407489.commit-9b51f8e.tgz",
+      "integrity": "sha512-gxyHDtwaLiAOwhdQFbBC2YnTUwEx/+CoSGkEhsIRLn0j8EbS4PWl7Dm16A7qBJhcDX0UE66SwogOhrcLtOC6Vg=="
     },
     "@dcl/kernel-interface": {
       "version": "2.0.0-20210922153939.commit-017905d",
@@ -1794,9 +1800,9 @@
       "integrity": "sha512-Hxx9pucG11kzW72URoc8D4yG0rbbo7ddFcDoxDjUvaxzTQtxekNIGfefo1tYCl5ypNGopnJSiGh6fu+XRz/q1Q=="
     },
     "@dcl/posix": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.1.tgz",
-      "integrity": "sha512-NMrIIxslGTt+F3E/9qmedch2szTTLyPGZor3+u+A7h7RqNU52O1sZrdmbHzOWaKjZ5oUXB8a//ed6yjESqWdmQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.4.tgz",
+      "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/schemas": {
       "version": "3.1.1",
@@ -1825,9 +1831,9 @@
       }
     },
     "@dcl/unity-renderer": {
-      "version": "1.0.14200-20210922132841.commit-60bce3d",
-      "resolved": "https://registry.npmjs.org/@dcl/unity-renderer/-/unity-renderer-1.0.14200-20210922132841.commit-60bce3d.tgz",
-      "integrity": "sha512-8SVPEP4dmcq/74SsttqkqF9JD9/9HrIET8hPTZVELkAzSRkiYQdFU8AnKZ0JsAmOkdikvR3lZxgtnA9cj1QPgQ=="
+      "version": "1.0.31824-20220330201254.commit-c617627",
+      "resolved": "https://registry.npmjs.org/@dcl/unity-renderer/-/unity-renderer-1.0.31824-20220330201254.commit-c617627.tgz",
+      "integrity": "sha512-/PgxAsBJ4vjK+kSEiNgLzmjAzYfz8zp59E2MT0LY9WXPTRWIMzji8HKGgS1DmncEREjo19bUnpqeutlPulvLTQ=="
     },
     "@dcl/urn-resolver": {
       "version": "1.2.1",
@@ -5897,9 +5903,9 @@
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
     },
     "@types/http-proxy": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
-      "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+      "version": "1.17.8",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz",
+      "integrity": "sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==",
       "requires": {
         "@types/node": "*"
       }
@@ -11563,20 +11569,40 @@
       }
     },
     "decentraland-ecs": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.6.8.tgz",
-      "integrity": "sha512-FP/22o+UECLQncrCa/W9T0J1zQ77rkcHLo4/eIG6dq9iTmiCy33ANtOKU/bmlNvrVmY9GFtIPakGEYCo3UuGQw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.10.0.tgz",
+      "integrity": "sha512-WMjn/T+tE4Nh55xN6hyCdwCZ7k6fTB00bMpZw1UHLkxu0L7dbsitkNfUjbS9U1bY8hwaC0lTRr8Kjrr80m9X0Q==",
       "requires": {
-        "@dcl/amd": "6.6.8",
-        "@dcl/build-ecs": "6.6.8",
-        "@dcl/kernel": "1.0.0-1217331229.commit-f70a80e",
-        "@dcl/posix": "1.0.1",
-        "@dcl/unity-renderer": "1.0.14200-20210922132841.commit-60bce3d",
+        "@dcl/amd": "6.10.0",
+        "@dcl/build-ecs": "6.10.0",
+        "@dcl/kernel": "^1.0.0-1959721167.commit-e8e7260",
+        "@dcl/posix": "^1.0.4",
+        "@dcl/schemas": "^4.1.0",
+        "@dcl/unity-renderer": "^1.0.31824-20220330201254.commit-c617627",
         "glob": "^7.1.7",
-        "http-proxy-middleware": "^2.0.1",
+        "http-proxy-middleware": "^2.0.3",
         "ignore": "^5.1.8"
       },
       "dependencies": {
+        "@dcl/schemas": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.2.0.tgz",
+          "integrity": "sha512-+YwEYRkUPtDuGhUFKSEKZxMe+ETqdIn0TBMyY8cJt+FijalXzOEFAPVj17TTCxz4V8SOW5qj2022N7FYzM/Qew==",
+          "requires": {
+            "ajv": "^7.1.0"
+          }
+        },
+        "ajv": {
+          "version": "7.2.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "braces": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -11607,11 +11633,11 @@
           }
         },
         "http-proxy-middleware": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
-          "integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
+          "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
           "requires": {
-            "@types/http-proxy": "^1.17.5",
+            "@types/http-proxy": "^1.17.8",
             "http-proxy": "^1.18.1",
             "is-glob": "^4.0.1",
             "is-plain-obj": "^3.0.0",
@@ -11628,19 +11654,24 @@
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
           "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
         },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
         "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
           }
         },
         "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
         },
         "to-regex-range": {
           "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dcl/urn-resolver": "^1.2.1",
     "decentraland-connect": "^3.0.0",
     "decentraland-dapps": "^12.34.0",
-    "decentraland-ecs": "^6.6.8",
+    "decentraland-ecs": "^6.10.0",
     "detect-browser": "^5.2.0",
     "eth-connect": "^6.0.2",
     "md5-file": "^5.0.0",


### PR DESCRIPTION
Update decentraland renderer to have the latest UI version of the explorer in local.

| before | after |
|---------|--------|
| ![Screen Shot 2022-04-01 at 15 27 09](https://user-images.githubusercontent.com/208789/161321450-fb044ac8-8d9f-4cb0-bc39-1f7eb736086e.jpg) | ![Screen Shot 2022-04-01 at 15 24 41](https://user-images.githubusercontent.com/208789/161321437-6d904b61-ddc5-4c89-a1a9-4fb896752c83.jpg) |

