### PR TITLE
feat: prevent desktop launch for recently logged in users

### DIFF
--- a/src/integration/browser.ts
+++ b/src/integration/browser.ts
@@ -45,6 +45,22 @@ export const isRecommendedBrowser = callOnce(() => {
   }
 })
 
+const BROWSER_LAST_SESSION_KEY = 'dcl-last-session-at'
+export const BROWSER_LAST_SESSION_EXPIRATION = 1000 * 60 * 60 * 24 * 7 /* one week */
+
+export const hasRecentlyLoggedIn = callOnce(() => {
+  const lastLoginAt = Number(localStorage.getItem(BROWSER_LAST_SESSION_KEY))
+  if (Number.isNaN(lastLoginAt)) {
+    return false
+  }
+
+  return lastLoginAt + BROWSER_LAST_SESSION_EXPIRATION > Date.now()
+})
+
+export function setAsRecentlyLoggedIn() {
+  localStorage.setItem(BROWSER_LAST_SESSION_KEY, String(Date.now()))
+}
+
 export function isWindows() {
   if ((navigator as any).userAgentData?.platform === 'Windows') {
     return true

--- a/src/integration/desktop.ts
+++ b/src/integration/desktop.ts
@@ -72,7 +72,7 @@ export async function launchDesktopApp() {
     return false
   }
 
-  // prevent launh if the user logged in into the web version recently
+  // prevent launch if the user logged in into the web version recently
   if (hasRecentlyLoggedIn()) {
     return false
   }

--- a/src/integration/desktop.ts
+++ b/src/integration/desktop.ts
@@ -1,7 +1,7 @@
 import { setDownloadNewVersion, setDownloadProgress, setDownloadReady, setKernelError } from '../state/actions'
 import { store } from '../state/redux'
 import { callOnce } from '../utils/callOnce'
-import { getCurrentPosition, isMobile } from './browser'
+import { getCurrentPosition, hasRecentlyLoggedIn, isMobile } from './browser'
 
 export const isElectron = callOnce((): boolean => {
   // Renderer process
@@ -69,6 +69,11 @@ export const initializeDesktopApp = callOnce(() => {
 export async function launchDesktopApp() {
   // prevent launch for desktop and mobile
   if (isElectron() || isMobile()) {
+    return false
+  }
+
+  // prevent launh if the user logged in into the web version recently
+  if (hasRecentlyLoggedIn()) {
     return false
   }
 

--- a/src/kernel-loader/index.ts
+++ b/src/kernel-loader/index.ts
@@ -19,6 +19,7 @@ import { ENV, NETWORK } from '../integration/queryParamsConfig'
 import { RequestManager } from 'eth-connect'
 import { errorToString } from '../utils/errorToString'
 import { isElectron, launchDesktopApp } from '../integration/desktop'
+import { setAsRecentlyLoggedIn } from '../integration/browser'
 
 // this function exists because decentraland-connect seems to return
 // invalid or cached values in chainId, ignoring network changes in the
@@ -74,6 +75,8 @@ export async function authenticate(providerType: ProviderType | null) {
     const kernel = store.getState().kernel.kernel
 
     if (!kernel) throw new Error('Kernel did not load yet')
+
+    setAsRecentlyLoggedIn()
 
     kernel.authenticate(provider, providerType == null /* isGuest */)
   } catch (err) {


### PR DESCRIPTION
## What happen

> This PR solves #183

It remember the last time a user authenticates into the browser version and prevent the desktop launch if it has pass less than a week

## how to test it

- you need to have the desktop version install in your computer
- open the test link 
- you will be prompted to open the desktop version
- cancel it
- log in to Decentraland in your browser
- reload the page
   - you should be prompted again
   - session should start automatically