### PR TITLE
feat: add cancel button into first sign

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -160,6 +160,7 @@
   background-color: rgba(0,0,0,.7);
   opacity: 1;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
 }
@@ -174,16 +175,38 @@
 
 .ui.modal.dcl.login-modal .loader-background {
   border-radius: 24px;
+  color: white;
 }
 
 .ui.modal.dcl.login-modal .loader-background .EthConnectAdvice {
   max-width: 380px;
-  margin-top: 128px;
+}
+
+.ui.modal.dcl.login-modal  .loader-background .ui.button {
+  color: var(--primary);
+  font-size: 14px;
+  line-height: 17px;
+  border-radius: 12px;
+  padding: 14px 46px;
+  min-width: auto;
 }
 
 .ui.modal.dcl.login-modal .loader {
   background-color: rgba(0,0,0,.2);
   border-radius: 100%;
+}
+
+.ui.modal.dcl.login-modal .ui.loader {
+  position: relative;
+  top: auto;
+  left: auto;
+  transform: unset;
+}
+
+.ui.modal.dcl.login-modal .ui.big.loader {
+  width: 2.28571429rem;
+  height: 2.28571429rem;
+  font-size: 1em
 }
 
 .ui.modal.dcl.login-modal .ui.big.loader {

--- a/src/components/auth/EthWalletSelector.tsx
+++ b/src/components/auth/EthWalletSelector.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { isCucumberProvider, isDapperProvider } from 'decentraland-dapps/dist/lib/eth'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
+import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import { LoginModal, LoginModalOptionType } from 'decentraland-ui/dist/components/LoginModal/LoginModal'
 import { isElectron } from '../../integration/desktop'
 import { EthConnectAdvice } from './EthConnectAdvice'
@@ -9,19 +10,23 @@ import { EthConnectAdvice } from './EthConnectAdvice'
 export interface WalletSelectorProps {
   open: boolean
   loading: boolean
+  canceling?: boolean
   provider?: ProviderType
   availableProviders?: ProviderType[]
   onLogin?: (provider: ProviderType | null) => void
-  onCancel?: () => void
+  onCancelLogin?: () => void
+  onClose?: () => void
 }
 
 export const EthWalletSelector: React.FC<WalletSelectorProps> = React.memo(({
   open,
   loading,
+  canceling,
   provider,
   availableProviders,
   onLogin,
-  onCancel
+  onCancelLogin,
+  onClose,
 }) => {
   const anchor = useMemo(() => {
     const a = document.createElement('a')
@@ -56,7 +61,7 @@ export const EthWalletSelector: React.FC<WalletSelectorProps> = React.memo(({
 
   return <LoginModal
     open={open}
-    onClose={onCancel}
+    onClose={onClose}
     i18n={{
       title: 'Connect your wallet',
       error: '',
@@ -64,9 +69,11 @@ export const EthWalletSelector: React.FC<WalletSelectorProps> = React.memo(({
     }}
   >
       {loading && <div className="loader-background">
-        <EthConnectAdvice provider={provider} />
+        <Loader active={loading} provider={provider} size="massive" />
+        <EthConnectAdvice provider={provider} style={{ marginTop: '27px'}} />
+        <div style={{ marginTop: '22px'}}>- or -</div>
+        <Button onClick={onCancelLogin} loading={canceling} style={{ marginTop: '28px'}}>cancel</Button>
       </div>}
-      {loading && <Loader active={loading} provider={provider} size="massive" />}
       {!isElectron() && <LoginModal.Option type={browserWallet || LoginModalOptionType.METAMASK} onClick={handleLoginInjected} />}
       <LoginModal.Option type={LoginModalOptionType.FORTMATIC} onClick={handleLoginFortmatic} />
       <LoginModal.Option type={LoginModalOptionType.WALLET_CONNECT} onClick={handleLoginWalletConnect}  />

--- a/src/components/auth/EthWalletSelector.tsx
+++ b/src/components/auth/EthWalletSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { isCucumberProvider, isDapperProvider } from 'decentraland-dapps/dist/lib/eth'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'

--- a/src/components/auth/EthWalletSelector.tsx
+++ b/src/components/auth/EthWalletSelector.tsx
@@ -68,12 +68,6 @@ export const EthWalletSelector: React.FC<WalletSelectorProps> = React.memo(({
       subtitle: ''
     }}
   >
-      {loading && <div className="loader-background">
-        <Loader active={loading} provider={provider} size="massive" />
-        <EthConnectAdvice provider={provider} style={{ marginTop: '27px'}} />
-        <div style={{ marginTop: '22px'}}>- or -</div>
-        <Button onClick={onCancelLogin} loading={canceling} style={{ marginTop: '28px'}}>cancel</Button>
-      </div>}
       {!isElectron() && <LoginModal.Option type={browserWallet || LoginModalOptionType.METAMASK} onClick={handleLoginInjected} />}
       <LoginModal.Option type={LoginModalOptionType.FORTMATIC} onClick={handleLoginFortmatic} />
       <LoginModal.Option type={LoginModalOptionType.WALLET_CONNECT} onClick={handleLoginWalletConnect}  />
@@ -86,5 +80,11 @@ export const EthWalletSelector: React.FC<WalletSelectorProps> = React.memo(({
           {'here'}
         </a>.
       </small>
+      {loading && <div className="loader-background">
+        <Loader active={loading} provider={provider} size="massive" />
+        <EthConnectAdvice provider={provider} style={{ marginTop: '27px'}} />
+        <div style={{ marginTop: '22px'}}>- or -</div>
+        <Button onClick={onCancelLogin} loading={canceling} style={{ marginTop: '28px'}}>cancel login</Button>
+      </div>}
     </LoginModal>
 })

--- a/src/components/auth/LoginContainer.tsx
+++ b/src/components/auth/LoginContainer.tsx
@@ -62,7 +62,7 @@ export interface LoginContainerDispatch {
 
 export const LoginContainer: React.FC<LoginContainerProps & LoginContainerDispatch> = ({ onLogin, onCancelLogin, stage, isWallet, isGuest, provider, kernelReady, availableProviders }) => {
   const [ showWalletSelector, setShowWalletSelector ] = useState(false)
-  const onSelect = useCallback(
+  const handleOpenSelector = useCallback(
     () => {
       if (isElectron() && onLogin) {
         onLogin(ProviderType.WALLET_CONNECT)
@@ -73,8 +73,17 @@ export const LoginContainer: React.FC<LoginContainerProps & LoginContainerDispat
     },
     [onLogin]
   )
-  const onCancel = useCallback(() => setShowWalletSelector(false), [])
-  const onGuest = useCallback(() => onLogin && onLogin(null), [onLogin])
+  const handleCloseSelector = useCallback(() => setShowWalletSelector(false), [])
+
+  const [ canceling, setCanceling ] = useState(false)
+  const handleCancelLogin = useCallback(() => {
+    if (onCancelLogin) {
+      setCanceling(true)
+      onCancelLogin()
+    }
+  }, [ onCancelLogin, setCanceling ])
+
+  const handleGuestLogin = useCallback(() => onLogin && onLogin(null), [onLogin])
   const loading = useMemo(() => {
     return stage === LoginState.SIGNATURE_PENDING ||
       stage === LoginState.WAITING_PROFILE ||
@@ -107,8 +116,8 @@ export const LoginContainer: React.FC<LoginContainerProps & LoginContainerDispat
           <p>Sign In or Create an Account</p>
         </div>
         <div>
-          <LoginWalletItem loading={loading} active={isWallet} onClick={onSelect} provider={providerInUse} onCancel={onCancelLogin} />
-          <LoginGuestItem loading={loading} active={isGuest} onClick={onGuest} />
+          <LoginWalletItem loading={loading} active={isWallet} onClick={handleOpenSelector} provider={providerInUse} onCancelLogin={handleCancelLogin} canceling={canceling} />
+          <LoginGuestItem loading={loading} active={isGuest} onClick={handleGuestLogin} />
         </div>
         <div style={{ visibility: desktopAvailable ? 'visible' : 'hidden' }}>
           <a className="DownloadDesktopApp" href="https://decentraland.org/download/" target="_blank" rel="noreferrer noopener">
@@ -123,7 +132,9 @@ export const LoginContainer: React.FC<LoginContainerProps & LoginContainerDispat
         availableProviders={availableProviders || defaultAvailableProviders}
         provider={providerInUse}
         onLogin={onLogin}
-        onCancel={onCancel}
+        canceling={canceling}
+        onCancelLogin={handleCancelLogin}
+        onClose={handleCloseSelector}
       />
     </main>
   )

--- a/src/components/auth/LoginItemContainer.tsx
+++ b/src/components/auth/LoginItemContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React from 'react'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'

--- a/src/components/auth/LoginItemContainer.tsx
+++ b/src/components/auth/LoginItemContainer.tsx
@@ -9,22 +9,16 @@ import { EthConnectAdvice } from './EthConnectAdvice'
 
 export type LoginItemContainerProps = {
   onClick?: () => void,
-  onCancel?: () => void,
+  onCancelLogin?: () => void,
   className?: string
   loading?: boolean
+  canceling?: boolean
   active?: boolean
   provider?: ProviderType
   children?: React.ReactNode
 }
 
-export const LoginItemContainer = React.memo(function ({ children, className, loading, active, provider, onClick, onCancel }: LoginItemContainerProps) {
-  const [ cancel, setCancel ] = useState(false)
-  const handleCancel = useCallback(() => {
-    setCancel(true)
-    if (onCancel) {
-      onCancel()
-    }
-  }, [ onCancel, setCancel ])
+export const LoginItemContainer = React.memo(function ({ children, className, loading, canceling, active, provider, onClick, onCancelLogin }: LoginItemContainerProps) {
 
   return <div
       className={`LoginItemContainer ${className || ''} ${loading ? 'loading' : ''} ${active ? 'active' : ''}`}
@@ -37,8 +31,8 @@ export const LoginItemContainer = React.memo(function ({ children, className, lo
     {loading && active && <div className="loader-background">
       <Loader active={active && loading} provider={provider} size="massive" />
       {provider && <EthConnectAdvice provider={provider} style={{ marginTop: '27px'}} />}
-      {onCancel && provider && <div style={{ marginTop: '22px'}}>- or -</div>}
-      {onCancel && provider && <Button onClick={handleCancel} loading={cancel} style={{ marginTop: '28px'}}>cancel</Button>}
+      {onCancelLogin && provider && <div style={{ marginTop: '22px'}}>- or -</div>}
+      {onCancelLogin && provider && <Button onClick={onCancelLogin} loading={canceling} style={{ marginTop: '28px'}}>cancel</Button>}
     </div>}
   </div>
 })


### PR DESCRIPTION
Solves: #198

## What happen

Users (mainly on desktop) report that some time they are not able to connect because wallet-connect never ask for a sign to complete the login, and they stay in the first loading page forever.

<img width="670" alt="Screen Shot 2022-04-29 at 11 54 53" src="https://user-images.githubusercontent.com/208789/166008517-6cb7737e-c3b6-4d5a-a6c3-784fa431d2ec.png">

## Solution

Add a cancel button to allow users to clear the current initialized session from local storage and reload the page to restart the process

<img width="655" alt="Screen Shot 2022-04-29 at 12 02 38" src="https://user-images.githubusercontent.com/208789/166009543-a3d01d4e-882b-45f2-b225-2dab409ee5cd.png">


