### PR TITLE
update: copy for Guest login

### DIFF
--- a/src/components/auth/LoginItemNewContainer.tsx
+++ b/src/components/auth/LoginItemNewContainer.tsx
@@ -127,7 +127,7 @@ export const LoginGuestItemNew = React.memo((props: LoginItemNewContainerProps) 
         <span>Limited social features</span>
       </SelectionLabel>
       <SelectionLabel className={'LoginWalletItem__SuccessLabel'}>
-        <span>Cannot receive NTFs</span>
+        <span>Cannot receive NFTs</span>
       </SelectionLabel>
     </div>
 


### PR DESCRIPTION
Previously was a typo as "NTFs". Given the prevalence of NFTs in Decentraland, seems like a quick fix.

![Screen Shot 2022-07-05 at 10 37 02 PM](https://user-images.githubusercontent.com/1126836/177456132-a4ddd29e-2fbd-4e46-898f-ca0b77661d7c.png)

