### PR TITLE
fix: update decentraland-connect with lazy loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dcl/schemas": "^4.15.0",
         "@dcl/urn-resolver": "^1.4.0",
         "@types/validator": "^13.7.3",
-        "decentraland-connect": "^3.3.1",
+        "decentraland-connect": "^3.3.2",
         "decentraland-dapps": "^13.7.0",
         "decentraland-ecs": "^6.10.0",
         "decentraland-ui": "^3.55.0",
@@ -27235,9 +27235,9 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.1.tgz",
-      "integrity": "sha512-25UqNGWJF9ChnCZT7KpXGjLxcgAAATT2wLRD5md01rbBjS4rl1AFrCKbJcDxfZeheav0bi1s/ukMZCHmoPQcBQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.2.tgz",
+      "integrity": "sha512-arbOpzTajdWYKN/Gx29Y/tqdvpmKav4iTsxYlkDqjkbxzIlN/LRoGc6HtHUiqbbokjYphAvYBusvaduZCtZ7+g==",
       "dependencies": {
         "@dcl/schemas": "^3.9.0",
         "@types/node": "^10.1.2",
@@ -27320,50 +27320,6 @@
         "redux-saga": "^1.1.3"
       }
     },
-    "node_modules/decentraland-dapps/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-    },
-    "node_modules/decentraland-dapps/node_modules/ajv": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/decentraland-dapps/node_modules/decentraland-connect": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.2.tgz",
-      "integrity": "sha512-arbOpzTajdWYKN/Gx29Y/tqdvpmKav4iTsxYlkDqjkbxzIlN/LRoGc6HtHUiqbbokjYphAvYBusvaduZCtZ7+g==",
-      "dependencies": {
-        "@dcl/schemas": "^3.9.0",
-        "@types/node": "^10.1.2",
-        "@walletconnect/web3-provider": "^1.6.5",
-        "@web3-react/fortmatic-connector": "^6.1.6",
-        "@web3-react/injected-connector": "^6.0.7",
-        "@web3-react/network-connector": "^6.1.3",
-        "@web3-react/types": "^6.0.7",
-        "@web3-react/walletconnect-connector": "^7.0.2-alpha.0",
-        "@web3-react/walletlink-connector": "^6.2.13"
-      }
-    },
-    "node_modules/decentraland-dapps/node_modules/decentraland-connect/node_modules/@dcl/schemas": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.13.0.tgz",
-      "integrity": "sha512-PCwogjKmVTfGLQaSbrQcTJXj76n5rCFb5uVKZ2lX0k3GAQg+PGzFttZCWW89PjXFCr48ciVMgH4jXf0xxgS8Qw==",
-      "dependencies": {
-        "ajv": "^7.1.0"
-      }
-    },
     "node_modules/decentraland-dapps/node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -27371,11 +27327,6 @@
       "engines": {
         "node": ">=0.8.x"
       }
-    },
-    "node_modules/decentraland-dapps/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/decentraland-ecs": {
       "version": "6.10.0",
@@ -71610,9 +71561,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decentraland-connect": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.1.tgz",
-      "integrity": "sha512-25UqNGWJF9ChnCZT7KpXGjLxcgAAATT2wLRD5md01rbBjS4rl1AFrCKbJcDxfZeheav0bi1s/ukMZCHmoPQcBQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.2.tgz",
+      "integrity": "sha512-arbOpzTajdWYKN/Gx29Y/tqdvpmKav4iTsxYlkDqjkbxzIlN/LRoGc6HtHUiqbbokjYphAvYBusvaduZCtZ7+g==",
       "requires": {
         "@dcl/schemas": "^3.9.0",
         "@types/node": "^10.1.2",
@@ -71683,57 +71634,10 @@
         "typesafe-actions": "^2.0.3"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
-        "ajv": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "decentraland-connect": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.2.tgz",
-          "integrity": "sha512-arbOpzTajdWYKN/Gx29Y/tqdvpmKav4iTsxYlkDqjkbxzIlN/LRoGc6HtHUiqbbokjYphAvYBusvaduZCtZ7+g==",
-          "requires": {
-            "@dcl/schemas": "^3.9.0",
-            "@types/node": "^10.1.2",
-            "@walletconnect/web3-provider": "^1.6.5",
-            "@web3-react/fortmatic-connector": "^6.1.6",
-            "@web3-react/injected-connector": "^6.0.7",
-            "@web3-react/network-connector": "^6.1.3",
-            "@web3-react/types": "^6.0.7",
-            "@web3-react/walletconnect-connector": "^7.0.2-alpha.0",
-            "@web3-react/walletlink-connector": "^6.2.13"
-          },
-          "dependencies": {
-            "@dcl/schemas": {
-              "version": "3.13.0",
-              "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.13.0.tgz",
-              "integrity": "sha512-PCwogjKmVTfGLQaSbrQcTJXj76n5rCFb5uVKZ2lX0k3GAQg+PGzFttZCWW89PjXFCr48ciVMgH4jXf0xxgS8Qw==",
-              "requires": {
-                "ajv": "^7.1.0"
-              }
-            }
-          }
-        },
         "events": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
           "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dcl/schemas": "^4.15.0",
         "@dcl/urn-resolver": "^1.4.0",
         "@types/validator": "^13.7.3",
-        "decentraland-connect": "^3.3.2",
+        "decentraland-connect": "^3.4.0",
         "decentraland-dapps": "^13.7.0",
         "decentraland-ecs": "^6.10.0",
         "decentraland-ui": "^3.55.0",
@@ -27235,11 +27235,11 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.2.tgz",
-      "integrity": "sha512-arbOpzTajdWYKN/Gx29Y/tqdvpmKav4iTsxYlkDqjkbxzIlN/LRoGc6HtHUiqbbokjYphAvYBusvaduZCtZ7+g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.4.0.tgz",
+      "integrity": "sha512-+6cjUnDZFyjj/+SAAjYbdZHHDdF7q7z7ZenRM85e3HHl9R8/XA9335F9kowCTKO0TjjLC0lj9FTm7DdtmPHWhg==",
       "dependencies": {
-        "@dcl/schemas": "^3.9.0",
+        "@dcl/schemas": "^6.4.2",
         "@types/node": "^10.1.2",
         "@walletconnect/web3-provider": "^1.6.5",
         "@web3-react/fortmatic-connector": "^6.1.6",
@@ -27251,11 +27251,13 @@
       }
     },
     "node_modules/decentraland-connect/node_modules/@dcl/schemas": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.13.0.tgz",
-      "integrity": "sha512-PCwogjKmVTfGLQaSbrQcTJXj76n5rCFb5uVKZ2lX0k3GAQg+PGzFttZCWW89PjXFCr48ciVMgH4jXf0xxgS8Qw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.4.2.tgz",
+      "integrity": "sha512-yO8GgC7RIU17951VBGIx2tA0xMVRv6Ia7rR6V97yY77/fYLAIn1FqW/20MEmonDzyJJ5YnuDa/8gVk3XusIXYA==",
       "dependencies": {
-        "ajv": "^7.1.0"
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0"
       }
     },
     "node_modules/decentraland-connect/node_modules/@types/node": {
@@ -27264,9 +27266,9 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/decentraland-connect/node_modules/ajv": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -27276,6 +27278,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/decentraland-connect/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/decentraland-connect/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
       }
     },
     "node_modules/decentraland-connect/node_modules/json-schema-traverse": {
@@ -71561,11 +71582,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decentraland-connect": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.3.2.tgz",
-      "integrity": "sha512-arbOpzTajdWYKN/Gx29Y/tqdvpmKav4iTsxYlkDqjkbxzIlN/LRoGc6HtHUiqbbokjYphAvYBusvaduZCtZ7+g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.4.0.tgz",
+      "integrity": "sha512-+6cjUnDZFyjj/+SAAjYbdZHHDdF7q7z7ZenRM85e3HHl9R8/XA9335F9kowCTKO0TjjLC0lj9FTm7DdtmPHWhg==",
       "requires": {
-        "@dcl/schemas": "^3.9.0",
+        "@dcl/schemas": "^6.4.2",
         "@types/node": "^10.1.2",
         "@walletconnect/web3-provider": "^1.6.5",
         "@web3-react/fortmatic-connector": "^6.1.6",
@@ -71577,11 +71598,13 @@
       },
       "dependencies": {
         "@dcl/schemas": {
-          "version": "3.13.0",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.13.0.tgz",
-          "integrity": "sha512-PCwogjKmVTfGLQaSbrQcTJXj76n5rCFb5uVKZ2lX0k3GAQg+PGzFttZCWW89PjXFCr48ciVMgH4jXf0xxgS8Qw==",
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.4.2.tgz",
+          "integrity": "sha512-yO8GgC7RIU17951VBGIx2tA0xMVRv6Ia7rR6V97yY77/fYLAIn1FqW/20MEmonDzyJJ5YnuDa/8gVk3XusIXYA==",
           "requires": {
-            "ajv": "^7.1.0"
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-keywords": "^5.1.0"
           }
         },
         "@types/node": {
@@ -71590,14 +71613,28 @@
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "ajv": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2",
             "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
           }
         },
         "json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dcl/schemas": "^4.15.0",
     "@dcl/urn-resolver": "^1.4.0",
     "@types/validator": "^13.7.3",
-    "decentraland-connect": "^3.3.1",
+    "decentraland-connect": "^3.3.2",
     "decentraland-dapps": "^13.7.0",
     "decentraland-ecs": "^6.10.0",
     "decentraland-ui": "^3.55.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dcl/schemas": "^4.15.0",
     "@dcl/urn-resolver": "^1.4.0",
     "@types/validator": "^13.7.3",
-    "decentraland-connect": "^3.3.2",
+    "decentraland-connect": "^3.4.0",
     "decentraland-dapps": "^13.7.0",
     "decentraland-ecs": "^6.10.0",
     "decentraland-ui": "^3.55.0",


### PR DESCRIPTION
The new includes an lazy `ajv` compiler that prevents unnecessary compilation

![flamegraph-explorer](https://user-images.githubusercontent.com/208789/214198659-8b0a3838-4999-464e-b145-e8c0c3a48fcb.jpg)

Issues:
- decentraland/decentraland-connect#43
- decentraland/unity-renderer#4027