### PR TITLE
fix: set video as muted

### DIFF
--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -804,6 +804,7 @@ exports[`Storyshots Explorer/base/LoadingRender Template 1`] = `
     autoPlay={true}
     height="150"
     loop={true}
+    muted={true}
     src="loading.mp4"
     width="150"
   />

--- a/src/components/common/Loading/LoadingRender.tsx
+++ b/src/components/common/Loading/LoadingRender.tsx
@@ -4,7 +4,7 @@ import './LoadingRender.css'
 
 export const LoadingRender = React.memo(function () {
   return <div className="LoadingRender">
-    <video src={video} loop width="150" height="150" autoPlay />
+    <video src={video} loop width="150" height="150" muted autoPlay />
     <p>We are downloading the latest version of Decentraland. You'll be up and running in a few seconds!</p>
   </div>
 })


### PR DESCRIPTION
Adding muted prop will prevent some browsers block the loading video 

<img width="862" alt="Screenshot 2023-01-25 at 15 10 03" src="https://user-images.githubusercontent.com/208789/214647115-3735db9b-69d7-46ab-b18c-95e85fb79d97.png">
