### PR TITLE
chore: restore rollout to 100% on .org

### DIFF
--- a/.github/workflows/set-rollouts.yml
+++ b/.github/workflows/set-rollouts.yml
@@ -58,4 +58,4 @@ jobs:
           # Rollout information
           deploymentDomain: "play.decentraland.org"
           deploymentName: "_site"
-          percentage: 0
+          percentage: 100


### PR DESCRIPTION
For the transition of the `@dcl/explorer` we set the rollout to prod in 0%, so we're restoring it.