### PR TITLE
chore: handle switch to network for non injected wallets - decentraland/unity-renderer#5091

### DIFF
--- a/src/components/errors/ErrorContainer.tsx
+++ b/src/components/errors/ErrorContainer.tsx
@@ -50,8 +50,8 @@ export const ErrorContainer = React.memo(function (props: ErrorContainerProps) {
   if (props.error.type === ErrorType.NOT_MOBILE) return <ErrorNoMobile />
   if (props.error.type === ErrorType.NOT_SUPPORTED) return <ErrorNotSupported />
   if (props.error.type === ErrorType.NET_MISMATCH) {
-    const { wantedChainId, providerChainId } = props.error.extra!
-    return <ErrorNetworkMismatch wantedChainId={wantedChainId} providerChainId={providerChainId} />}
+    const { wantedChainId, providerChainId, providerType } = props.error.extra!
+    return <ErrorNetworkMismatch wantedChainId={wantedChainId} providerChainId={providerChainId} providerType={providerType} />}
   if (props.error.type === ErrorType.AVATAR_ERROR) return <ErrorAvatarLoading />
 
   return (

--- a/src/components/errors/ErrorNetworkMismatch.tsx
+++ b/src/components/errors/ErrorNetworkMismatch.tsx
@@ -1,19 +1,37 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import { ChainId, getChainName } from '@dcl/schemas/dist/dapps/chain-id'
+import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { ErrorContainer, ErrorDetails, ErrorImage } from './Error'
 import errorImage from '../../images/errors/robotsmiling.png'
-import { switchToChainId } from '../../eth/provider'
+import { disconnect, switchToChainId } from '../../eth/provider'
 import './errors.css'
 
 export interface ErrorNetworkMismatchProps {
   wantedChainId: ChainId
   providerChainId: ChainId
+  providerType: ProviderType
 }
 
 export const ErrorNetworkMismatch = React.memo(function (props: ErrorNetworkMismatchProps)  {
   const providerChainName = getChainName(props.providerChainId)
   const wantedChainName = getChainName(props.wantedChainId)
+
+  const handleSwitchTo = useCallback(async function () {
+    // Switch to the wanted network if injected
+    if (props.providerType === ProviderType.INJECTED) {
+      return switchToChainId(props.wantedChainId, props.providerChainId)
+    }
+
+    // Otherwise, disconnect and reload the page
+    await disconnect()
+    window.location.reload()
+  }, [
+    props.wantedChainId,
+    props.providerChainId,
+    props.providerType
+  ])
+
   return (
     <ErrorContainer id="error-network-mismatch">
       <ErrorDetails
@@ -26,7 +44,7 @@ export const ErrorNetworkMismatch = React.memo(function (props: ErrorNetworkMism
           </>
         }
       >
-        <Button primary onClick={() => switchToChainId(props.wantedChainId, props.providerChainId)}>
+        <Button primary onClick={handleSwitchTo}>
           Switch to <strong>{wantedChainName}</strong>
         </Button>
       </ErrorDetails>

--- a/src/kernel-loader/index.ts
+++ b/src/kernel-loader/index.ts
@@ -46,8 +46,9 @@ export async function authenticate(providerType: ProviderType | null) {
           ),
           code: ErrorType.NET_MISMATCH,
           extra: {
+            providerType,
             providerChainId: providerChainId,
-            wantedChainId: wantedChainId
+            wantedChainId: wantedChainId,
           }
         })
       )
@@ -64,6 +65,7 @@ export async function authenticate(providerType: ProviderType | null) {
             ),
             code: ErrorType.NET_MISMATCH,
             extra: {
+              providerType,
               providerChainId: providerChainId,
               wantedChainId: wantedChainId
             }


### PR DESCRIPTION
How to test it:
- change your network to Mumbai
- connect with your wallet
- when you get the network mismatch error, click on the "switch to mainnet" button
- depending on your wallet you should get different behavior:
  - if you are connected with a browser waller you should be prompt to change your network
  - otherwise, you should be redirect to the initial page

solves:
- decentraland/unity-renderer#5091