### PR TITLE
fix: Send wc2 on the login tracking

### DIFF
--- a/src/components/auth/LoginContainer.tsx
+++ b/src/components/auth/LoginContainer.tsx
@@ -80,9 +80,7 @@ const mergeProps = (
           : providerType
 
       track('click_login_button', {
-        // I don't want to diff if I'm using Wallet Connect V2 in the tracking.
-        // I just care about Wallet Connect as a whole, not its version.
-        provider_type: providerType || 'guest',
+        provider_type: _providerType || 'guest',
         action_type
       })
 


### PR DESCRIPTION
When connecting to WalletConnect v2, track that instead of sending normal WalletConnect as provider.