### PR TITLE
feat: Remove WC2 flag

### DIFF
--- a/src/components/auth/LoginContainer.tsx
+++ b/src/components/auth/LoginContainer.tsx
@@ -16,7 +16,7 @@ import { disconnect } from '../../eth/provider'
 import { track } from '../../utils/tracking'
 import Main from '../common/Layout/Main'
 import { SHOW_WALLET_SELECTOR } from '../../integration/url'
-import { ABTestingVariant, FeatureFlags, getFeatureVariantName, isFeatureEnabled } from '../../state/selectors'
+import { ABTestingVariant, FeatureFlags, getFeatureVariantName } from '../../state/selectors'
 import './LoginContainer.css'
 
 export const defaultAvailableProviders = []
@@ -43,7 +43,6 @@ const mapStateToProps = (state: StoreType): LoginContainerProps => {
     kernelReady: state.kernel.ready,
     rendererReady: state.renderer.ready,
     isGuest: state.session.kernelState ? state.session.kernelState.isGuest : undefined,
-    isWalletConnectV2Enabled: isFeatureEnabled(state, FeatureFlags.WalletConnectV2),
     isWallet: state.session.kernelState ? !state.session.kernelState.isGuest && !!state.session.connection : undefined
   }
 }
@@ -74,10 +73,7 @@ const mergeProps = (
     onLogin: (providerType: ProviderType | null, action_type?: TrackingActionType) => {
       // The UI will dispatch ProviderType.WALLET_CONNECT disregarding the version required.
       // We need to map it to the correct version to provide it to the connection library.
-      const _providerType =
-        providerType === ProviderType.WALLET_CONNECT && stateProps.isWalletConnectV2Enabled
-          ? ProviderType.WALLET_CONNECT_V2
-          : providerType
+      const _providerType = providerType === ProviderType.WALLET_CONNECT ? ProviderType.WALLET_CONNECT_V2 : providerType
 
       track('click_login_button', {
         provider_type: _providerType || 'guest',
@@ -97,7 +93,6 @@ export interface LoginContainerProps {
   rendererReady: boolean
   isGuest?: boolean
   isWallet?: boolean
-  isWalletConnectV2Enabled: boolean
   seamlessLogin?: ABTestingVariant
 }
 

--- a/src/integration/featureFlags.ts
+++ b/src/integration/featureFlags.ts
@@ -1,12 +1,9 @@
 import { fetchFlags } from '@dcl/feature-flags'
 import { FeatureFlagsResult } from '@dcl/feature-flags'
-import { connection } from 'decentraland-connect/dist'
-import { ProviderType } from '@dcl/schemas'
 import { setFeatureFlags } from '../state/actions'
 import { store } from '../state/redux'
 import { defaultFeatureFlagsState } from '../state/types'
 import { callOnce } from '../utils/callOnce'
-import { FeatureFlags, isFeatureEnabled } from '../state/selectors'
 
 /**
  * Fetches feature flags from the server and stores them in the redux store.
@@ -15,42 +12,12 @@ export const initializeFeatureFlags = callOnce(async () => {
   let ff = defaultFeatureFlagsState as FeatureFlagsResult
 
   try {
-    ff = await fetchFlags({ applicationName: ['explorer', 'dapps'] })
+    ff = await fetchFlags({ applicationName: ['explorer'] })
   } catch (err) {
     console.error('Error fetching feature flags', err)
   }
 
   store.dispatch(setFeatureFlags(ff))
 
-  handleWalletConnectConnection()
-
   return ff
 })
-
-/**
- * Disconnects the user when connected with a WalletConnect Version that is not the one defined in the feature flags.
- * This is done to prevent a user to keep using a wallet that will not / is not supported anymore.
- * Also to be able to easily rollback in case WC2 has too many flaws.
- * Once WC2 becomes the only supported WC version, this function can be removed.
- */
-export async function handleWalletConnectConnection() {
-  const connectionData = connection.getConnectionData()
-
-  // No connection data means the user has not connected on a previous session.
-  // Could also mean it has disconnected manually from the previous session.
-  if (!connectionData) {
-    return
-  }
-
-  const isWalletConnectV2Enabled = isFeatureEnabled(store.getState(), FeatureFlags.WalletConnectV2)
-
-  const { providerType } = connectionData
-
-  // Disconnect the user only if it has connected previously with a WC version different than the one defined in the feature flags.
-  if (
-    (providerType === ProviderType.WALLET_CONNECT && isWalletConnectV2Enabled) ||
-    (providerType === ProviderType.WALLET_CONNECT_V2 && !isWalletConnectV2Enabled)
-  ) {
-    await connection.disconnect()
-  }
-}

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -12,7 +12,6 @@ export function getRequiredAnalyticsContext(state: StoreType): SessionTraits {
 
 export enum FeatureFlags {
   Stream = 'explorer-stream',
-  WalletConnectV2 = 'dapps-wallet-connect-v2',
   SeamlessLogin = 'explorer-seamless_login_variant'
 }
 


### PR DESCRIPTION
The wallet connect flag is unnecessary given that version 1 does not work anymore.

This PRs makes it so version 2 is always used, preventing an unnecessary call to the feature flags server.