### PR TITLE
fix: Update explorer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@dcl/explorer": "^1.0.120168-20230605162254.commit-8cf9aed",
+        "@dcl/explorer": "^1.0.130879-20230714150601.commit-419b7fd",
         "@dcl/feature-flags": "^1.2.0",
         "@dcl/kernel-interface": "^2.0.0-20230512115658.commit-b582e05",
         "@dcl/schemas": "^8.1.0",
@@ -2194,9 +2194,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.120168-20230605162254.commit-8cf9aed",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.120168-20230605162254.commit-8cf9aed.tgz",
-      "integrity": "sha512-MIqUVjX1zdBkvzpqbOQ6Yv2e7xuhCHTYHRpUX1O7bah95Os3g1MWyasPCozMcMbyVk7f9/8VILULlh6PPeT7SQ=="
+      "version": "1.0.130879-20230714150601.commit-419b7fd",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.130879-20230714150601.commit-419b7fd.tgz",
+      "integrity": "sha512-viSXplQXMzW0YR2Rpe8ccz2rqFAR167Vrbwnmo+Jzu/7V76kCDtDn+H+7ocsIOY851H+lz8TcTNeBaMYEhOB9A=="
     },
     "node_modules/@dcl/feature-flags": {
       "version": "1.2.0",
@@ -43097,9 +43097,9 @@
       }
     },
     "@dcl/explorer": {
-      "version": "1.0.120168-20230605162254.commit-8cf9aed",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.120168-20230605162254.commit-8cf9aed.tgz",
-      "integrity": "sha512-MIqUVjX1zdBkvzpqbOQ6Yv2e7xuhCHTYHRpUX1O7bah95Os3g1MWyasPCozMcMbyVk7f9/8VILULlh6PPeT7SQ=="
+      "version": "1.0.130879-20230714150601.commit-419b7fd",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.130879-20230714150601.commit-419b7fd.tgz",
+      "integrity": "sha512-viSXplQXMzW0YR2Rpe8ccz2rqFAR167Vrbwnmo+Jzu/7V76kCDtDn+H+7ocsIOY851H+lz8TcTNeBaMYEhOB9A=="
     },
     "@dcl/feature-flags": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@dcl/explorer": "^1.0.120168-20230605162254.commit-8cf9aed",
+    "@dcl/explorer": "^1.0.130879-20230714150601.commit-419b7fd",
     "@dcl/feature-flags": "^1.2.0",
     "@dcl/kernel-interface": "^2.0.0-20230512115658.commit-b582e05",
     "@dcl/schemas": "^8.1.0",


### PR DESCRIPTION
This version includes the changes included in https://github.com/decentraland/unity-renderer/pull/5475.

As the `poseidon` catalyst was migrated to Sepolia, it had to be removed from the realm options for Goerli to prevent the usage of a catalyst from another network.

This is only required for local development. The @dcl/explorer version used in .zone and .org depend on the the releases from https://github.com/decentraland/unity-renderer
