### PR TITLE
fix: Show proper message when connecting with WC

### DIFF
--- a/src/components/auth/EthConnectAdvice.tsx
+++ b/src/components/auth/EthConnectAdvice.tsx
@@ -9,19 +9,25 @@ export type EthWalletSelectorAdviceProps = {
 export const EthConnectAdvice = React.memo((props: EthWalletSelectorAdviceProps) => {
   switch (props.provider) {
     case ProviderType.FORTMATIC:
-      return <span className="EthConnectAdvice" style={props.style}>
-        Please, follow the instructions of your fortmatic provider to continue.
-      </span>
+      return (
+        <span className="EthConnectAdvice" style={props.style}>
+          Please, follow the instructions of your fortmatic provider to continue.
+        </span>
+      )
 
     case ProviderType.INJECTED:
-      return <span className="EthConnectAdvice" style={props.style}>
-        Please, follow the instructions of your browser wallet provider to continue.
-      </span>
+      return (
+        <span className="EthConnectAdvice" style={props.style}>
+          Please, follow the instructions of your browser wallet provider to continue.
+        </span>
+      )
 
-    case ProviderType.WALLET_CONNECT:
-      return <span className="EthConnectAdvice" style={props.style}>
-        Please, follow the instructions of your mobile wallet provider to continue.
-      </span>
+    case ProviderType.WALLET_CONNECT_V2:
+      return (
+        <span className="EthConnectAdvice" style={props.style}>
+          Please, follow the instructions of your mobile wallet provider to continue.
+        </span>
+      )
 
     default:
       return null

--- a/src/components/auth/EthConnectAdvice.tsx
+++ b/src/components/auth/EthConnectAdvice.tsx
@@ -25,7 +25,7 @@ export const EthConnectAdvice = React.memo((props: EthWalletSelectorAdviceProps)
     case ProviderType.WALLET_CONNECT_V2:
       return (
         <span className="EthConnectAdvice" style={props.style}>
-          Please, follow the instructions of your mobile wallet provider to continue.
+          Please follow the instructions from your wallet provider's app on your mobile device to continue.
         </span>
       )
 

--- a/src/components/errors/ErrorNetworkMismatch.tsx
+++ b/src/components/errors/ErrorNetworkMismatch.tsx
@@ -13,24 +13,23 @@ export interface ErrorNetworkMismatchProps {
   providerType: ProviderType
 }
 
-export const ErrorNetworkMismatch = React.memo(function (props: ErrorNetworkMismatchProps)  {
+export const ErrorNetworkMismatch = React.memo(function (props: ErrorNetworkMismatchProps) {
   const providerChainName = getChainName(props.providerChainId)
   const wantedChainName = getChainName(props.wantedChainId)
 
-  const handleSwitchTo = useCallback(async function () {
-    // Switch to the wanted network if injected
-    if (props.providerType === ProviderType.INJECTED) {
-      return switchToChainId(props.wantedChainId, props.providerChainId)
-    }
+  const handleSwitchTo = useCallback(
+    async function () {
+      // Switch to the wanted network if injected or WC
+      if (props.providerType === ProviderType.INJECTED || props.providerType === ProviderType.WALLET_CONNECT_V2) {
+        return switchToChainId(props.wantedChainId, props.providerChainId)
+      }
 
-    // Otherwise, disconnect and reload the page
-    await disconnect()
-    window.location.reload()
-  }, [
-    props.wantedChainId,
-    props.providerChainId,
-    props.providerType
-  ])
+      // Otherwise, disconnect and reload the page
+      await disconnect()
+      window.location.reload()
+    },
+    [props.wantedChainId, props.providerChainId, props.providerType]
+  )
 
   return (
     <ErrorContainer id="error-network-mismatch">


### PR DESCRIPTION
+ Don't disconnect when switching network with WC. This prevented wallets like Zerion from allowing users to switch to the correct network!

<img width="749" alt="image" src="https://github.com/decentraland/explorer-website/assets/24811313/a5bc3d66-d4af-4c76-b2ed-f9648b5c1720">
