### PR TITLE
fix: bump eth-connect dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "decentraland-dapps": "^15.5.0",
         "decentraland-ui": "^4.1.0",
         "detect-browser": "^5.2.0",
-        "eth-connect": "^6.1.0",
+        "eth-connect": "^6.2.2",
         "md5-file": "^5.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -21377,9 +21377,9 @@
       }
     },
     "node_modules/eth-connect": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.1.0.tgz",
-      "integrity": "sha512-p5FN4GieTxwfJvgmGCPgXqL6w8/2cbLiTmNxpgQg881gSI0RdOShTHHu8amgxlj3VM4crovBx7UEKS2RGOhBLQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
     },
     "node_modules/eth-crypto": {
       "version": "1.9.0",
@@ -57485,9 +57485,9 @@
       }
     },
     "eth-connect": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.1.0.tgz",
-      "integrity": "sha512-p5FN4GieTxwfJvgmGCPgXqL6w8/2cbLiTmNxpgQg881gSI0RdOShTHHu8amgxlj3VM4crovBx7UEKS2RGOhBLQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
     },
     "eth-crypto": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "decentraland-dapps": "^15.5.0",
     "decentraland-ui": "^4.1.0",
     "detect-browser": "^5.2.0",
-    "eth-connect": "^6.1.0",
+    "eth-connect": "^6.2.2",
     "md5-file": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Bump eth-connect version to include fix that was causing loging in in firefox not to work. We are checking that the error key is not present or is undefined to make a response valid