### PR TITLE
fix: wrong segment initalization

### DIFF
--- a/src/integration/analytics.ts
+++ b/src/integration/analytics.ts
@@ -33,6 +33,7 @@ export const defaultAnalyticsOptions: AnalyticsOptions = {
 
 // TODO fill with segment keys and integrate identity server
 export function configureSegment() {
+  console.info('explorer-website: DEBUG_ANALYTICS', 'Host:', globalThis.location.host, 'Path:', globalThis.location.pathname);
   // all decentraland.org domains are considered PRD
   if (globalThis.location.host.endsWith('.decentraland.org')) {
     return initialize(AnalyticsAccount.PRD)

--- a/src/integration/analytics.ts
+++ b/src/integration/analytics.ts
@@ -33,11 +33,8 @@ export const defaultAnalyticsOptions: AnalyticsOptions = {
 
 // TODO fill with segment keys and integrate identity server
 export function configureSegment() {
-  if (DEBUG_ANALYTICS) {
-    console.info('explorer-website: DEBUG_ANALYTICS', 'Host:', globalThis.location.host, 'Path:', globalThis.location.pathname);
-  }
   // all decentraland.org domains are considered PRD
-  if (globalThis.location.host.includes('.decentraland.org')) {
+  if (globalThis.location.host.endsWith('decentraland.org')) {
     return initialize(AnalyticsAccount.PRD)
   }
 

--- a/src/integration/analytics.ts
+++ b/src/integration/analytics.ts
@@ -33,9 +33,11 @@ export const defaultAnalyticsOptions: AnalyticsOptions = {
 
 // TODO fill with segment keys and integrate identity server
 export function configureSegment() {
-  console.info('explorer-website: DEBUG_ANALYTICS', 'Host:', globalThis.location.host, 'Path:', globalThis.location.pathname);
+  if (DEBUG_ANALYTICS) {
+    console.info('explorer-website: DEBUG_ANALYTICS', 'Host:', globalThis.location.host, 'Path:', globalThis.location.pathname);
+  }
   // all decentraland.org domains are considered PRD
-  if (globalThis.location.host.endsWith('.decentraland.org')) {
+  if (globalThis.location.host.includes('.decentraland.org')) {
     return initialize(AnalyticsAccount.PRD)
   }
 


### PR DESCRIPTION
After the migration from `play.decentraland.org` to` decentraland.org/play` some metrics has been reported to dev environment instead of production, because the subdomains don't have extra `.` anymore