### PR TITLE
fix: Show Catalyst warning modal

### DIFF
--- a/src/components/warning/CatalystWarningContainer.css
+++ b/src/components/warning/CatalystWarningContainer.css
@@ -4,6 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 9999999;
 }
 
 .catalyst-warning-container div.catalyst-warning-content {


### PR DESCRIPTION
This PR changes the z-index of the catalyst confirmation modal so the users can continue the flow with a custom catalyst.