### PR TITLE
fix: Load until the profile is loaded

### DIFF
--- a/src/components/start/Start.container.ts
+++ b/src/components/start/Start.container.ts
@@ -1,16 +1,19 @@
 import { connect } from 'react-redux'
 import { isConnected, isConnecting, getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
-import { getProfileOfAddress } from 'decentraland-dapps/dist/modules/profile/selectors'
+import { LOAD_PROFILE_REQUEST } from 'decentraland-dapps/dist/modules/profile/actions'
+import { getProfileOfAddress, getLoading, getError } from 'decentraland-dapps/dist/modules/profile/selectors'
 import { StoreType } from '../../state/redux'
 import { Props } from './Start.types'
 import Start from './Start'
 
 const mapStateToProps = (state: StoreType): Props => {
   const wallet = getWallet(state)
+
   return {
     wallet,
     isConnecting: isConnecting(state),
     isConnected: isConnected(state),
+    isLoadingProfile: getLoading(state).some((a) => a.type === LOAD_PROFILE_REQUEST),
     profile: (wallet?.address && getProfileOfAddress(state, wallet?.address)) || null
   }
 }

--- a/src/components/start/Start.tsx
+++ b/src/components/start/Start.tsx
@@ -38,7 +38,7 @@ const useLocalStorageListener = (key: string) => {
 }
 
 export default function Start(props: Props) {
-  const { isConnected, isConnecting, wallet, profile } = props
+  const { isConnected, isConnecting, wallet, profile, isLoadingProfile } = props
   const [initialized, setInitialized] = useState(false)
   const [isLoadingExplorer, setIsLoadingExplorer] = useState(false)
   const [isLoadingAvatar, setIsLoadingAvatar] = useState(true)
@@ -94,7 +94,7 @@ export default function Start(props: Props) {
     return null
   }
 
-  if (isConnecting && !initialized) {
+  if (!initialized || isLoadingProfile || isConnecting) {
     return (
       <div className="explorer-website-start">
         <Loader active size="massive" />

--- a/src/components/start/Start.types.ts
+++ b/src/components/start/Start.types.ts
@@ -1,9 +1,10 @@
-import { Profile } from "@dcl/schemas"
-import { Wallet } from "decentraland-dapps/dist/modules/wallet/types"
+import { Profile } from '@dcl/schemas'
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 
 export type Props = {
   wallet: Wallet | null
   isConnected: boolean
   isConnecting: boolean
+  isLoadingProfile: boolean
   profile: Profile | null
 }


### PR DESCRIPTION
This PR makes the `Start` component wait until the profile has finished loading to prevent showing a user without name or avatar preview.