### PR TITLE
fix: Disconnect not being called

### DIFF
--- a/src/eth/provider.ts
+++ b/src/eth/provider.ts
@@ -49,9 +49,9 @@ export async function restoreConnection(): Promise<ConnectionResponse | null> {
 
 export async function disconnect(): Promise<void> {
   try {
+    await connection.disconnect()
     const requestManager = new RequestManager(await connection.getProvider())
     const account = (await requestManager.eth_accounts())[0]
-    await connection.disconnect()
     if (account) {
       localStorageClearIdentity(account)
     }

--- a/src/eth/provider.ts
+++ b/src/eth/provider.ts
@@ -49,12 +49,17 @@ export async function restoreConnection(): Promise<ConnectionResponse | null> {
 
 export async function disconnect(): Promise<void> {
   try {
-    await connection.disconnect()
-    const requestManager = new RequestManager(await connection.getProvider())
-    const account = (await requestManager.eth_accounts())[0]
-    if (account) {
-      localStorageClearIdentity(account)
+    try {
+      const requestManager = new RequestManager(await connection.getProvider())
+      const account = (await requestManager.eth_accounts())[0]
+      if (account) {
+        localStorageClearIdentity(account)
+      }
+    } catch (err) {
+      // Ignore the error if for some reason the account could not be obtained.
     }
+
+    await connection.disconnect()
     window.location.reload()
   } catch (err) {
     defaultWebsiteErrorTracker(err)


### PR DESCRIPTION
```
const requestManager = new RequestManager(await connection.getProvider())
const account = (await requestManager.eth_accounts())[0]
```

This code is throwing an error, thus connection.disconnect is not being called.
This change will at least fix the issue of the account not being disconnected after sign out.