### PR TITLE
fix: Remove root loader and fix guests

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,13 +26,11 @@
         height: 100%;
         overflow: hidden;
         touch-action: none;
-        background: #74a4d5;
-        background-size: 115%;
-        background-repeat: no-repeat;
-        background-position: right -90px bottom 25px;
+        background: radial-gradient(70% 108% at 90% 50%, #ff00f5 0%, #540880 100%);
       }
 
       #gameContainer {
+        background-color: black;
         width: 100vw;
         height: 100vh;
         position: relative;
@@ -44,25 +42,9 @@
         margin: auto;
       }
 
-      #gameContainer.loaded,
-      body {
+      #gameContainer.loaded {
         background: #090909 no-repeat 50% 5% !important;
         background-size: 170px 32px !important;
-      }
-
-      @media screen and (min-height: 500px) {
-        body {
-          background: #090909 no-repeat 50% 5% !important;
-          background-size: 170px 32px !important;
-        }
-      }
-
-      @media screen and (min-height: 800px) {
-        #gameContainer.loaded,
-        body {
-          background: #090909 no-repeat 50% 25% !important;
-          background-size: 170px 32px !important;
-        }
       }
 
       /* Without this, some of wallet link modal component backgrounds are being overwriten by other body styles */
@@ -94,38 +76,6 @@
         background: black none !important;
       }
 
-      #root-loading {
-        background-color: #f1f1f1;
-        position: fixed;
-        opacity: 1;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: 10000;
-        transition: opacity 0.3s ease-out;
-      }
-
-      #root-loading > div {
-        background-size: cover;
-        background-position: bottom center;
-        background-repeat: no-repeat;
-        background-color: #230b61;
-        background-image: url('%VITE_PUBLIC_URL%/images/background-v3@blur.jpg');
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        min-height: 790px;
-      }
-
-      @media only screen and (max-width: 991px) {
-        #root-loading > div {
-          background-size: cover;
-        }
-      }
-
       @font-face {
         font-family: sfregular;
         src: url(images/decentraland-connect/SF-UI-Text-Regular.otf);
@@ -142,10 +92,9 @@
   <body class="dcl-loading">
     <div id="gameContainer"></div>
     <div id="root"></div>
-    <div id="root-loading"><div></div></div>
     <audio autoplay id="voice-chat-audio"></audio>
     <!-- span.progress is to avoid a error on DCLUnityLoader  -->
-    <div class="progress" style="display: none;"></div>
+    <div class="progress" style="display: none"></div>
     <noscript>
       <div id="error-notsupported" class="hidden-error">
         <div class="errormessage">
@@ -196,6 +145,6 @@
       data-cf-beacon='{"token": "529363954dff44d8b036b8fb8879bcc5"}'
     ></script>
     <!-- End Cloudflare Web Analytics -->
-	  <script type="module" src="/src/index.tsx"></script>
+    <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo } from 'react'
 import { connect } from 'react-redux'
 import { useMobileMediaQuery } from 'decentraland-ui/dist/components/Media'
+import WalletProvider from 'decentraland-dapps/dist/providers/WalletProvider'
 import { StoreType } from '../state/redux'
 import { isElectron } from '../integration/desktop'
-import { SHOW_WALLET_SELECTOR } from '../integration/url'
+import { LOGIN_AS_GUEST, SHOW_WALLET_SELECTOR } from '../integration/url'
 import {
   FeatureFlags,
   isWaitingForRenderer,
@@ -110,12 +111,26 @@ const App: React.FC<AppProps> = (props) => {
     return <React.Fragment />
   }
 
-  if (props.waitingForRenderer || props.sessionReady || props.seamlessLogin === ABTestingVariant.Enabled || !props.featureFlagsLoaded) {
+  if (
+    props.waitingForRenderer ||
+    props.sessionReady ||
+    props.seamlessLogin === ABTestingVariant.Enabled ||
+    !props.featureFlagsLoaded
+  ) {
+    return <LoadingRender />
+  }
+
+  if (LOGIN_AS_GUEST) {
+    initializeKernel()
     return <LoadingRender />
   }
 
   if (props.isAuthDappEnabled && !isElectron()) {
-    return <Start />
+    return (
+      <WalletProvider>
+        <Start initializeKernel={initializeKernel} />
+      </WalletProvider>
+    )
   }
 
   if (isElectron() && props.isDesktopClientSignInWithAuthDappEnabled) {

--- a/src/components/start/Start.container.ts
+++ b/src/components/start/Start.container.ts
@@ -1,18 +1,26 @@
 import { connect } from 'react-redux'
-import { isConnected, isConnecting, getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
+import {
+  isConnected,
+  isConnecting,
+  getData as getWallet,
+  getError
+} from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { LOAD_PROFILE_REQUEST } from 'decentraland-dapps/dist/modules/profile/actions'
-import { getProfileOfAddress, getLoading, getError } from 'decentraland-dapps/dist/modules/profile/selectors'
+import { getProfileOfAddress, getLoading } from 'decentraland-dapps/dist/modules/profile/selectors'
 import { StoreType } from '../../state/redux'
-import { Props } from './Start.types'
+import { MapStateProps } from './Start.types'
 import Start from './Start'
 
-const mapStateToProps = (state: StoreType): Props => {
+const mapStateToProps = (state: StoreType): MapStateProps => {
   const wallet = getWallet(state)
+  const isWalletConnected = isConnected(state)
+  const isWalletConnecting = isConnecting(state)
 
   return {
     wallet,
-    isConnecting: isConnecting(state),
-    isConnected: isConnected(state),
+    isConnecting: isWalletConnecting,
+    isConnected: isWalletConnected,
+    hasInitializedConnection: getError(state) !== null || isWalletConnected || isWalletConnecting,
     isLoadingProfile: getLoading(state).some((a) => a.type === LOAD_PROFILE_REQUEST),
     profile: (wallet?.address && getProfileOfAddress(state, wallet?.address)) || null
   }

--- a/src/components/start/Start.css
+++ b/src/components/start/Start.css
@@ -64,7 +64,7 @@
   opacity: 0;
   position: absolute;
   transition: ease-out 2s;
-} 
+}
 
 .start-wearable-preview.loading .wearable-default-img {
   opacity: 0.9;

--- a/src/components/start/Start.tsx
+++ b/src/components/start/Start.tsx
@@ -5,8 +5,7 @@ import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon/Icon'
 import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
-import { LOGIN_AS_GUEST, SKIP_SETUP } from '../../integration/url'
-import { initializeKernel } from '../../integration/kernel'
+import { SKIP_SETUP } from '../../integration/url'
 import platformImg from '../../images/Platform.webp'
 import manDefault from '../../images/ManDefault.webp'
 import BannerContainer from '../banners/BannerContainer'
@@ -38,27 +37,15 @@ const useLocalStorageListener = (key: string) => {
 }
 
 export default function Start(props: Props) {
-  const { isConnected, isConnecting, wallet, profile, isLoadingProfile } = props
-  const [initialized, setInitialized] = useState(false)
+  const { isConnected, isConnecting, wallet, profile, initializeKernel, isLoadingProfile, hasInitializedConnection } =
+    props
   const [isLoadingExplorer, setIsLoadingExplorer] = useState(false)
   const [isLoadingAvatar, setIsLoadingAvatar] = useState(true)
   const decentralandConnectStorage = useLocalStorageListener('decentraland-connect-storage-key')
-
   const name = profile?.avatars[0].name
 
   useEffect(() => {
-    // remove loading component
-    const loadingElement = document.getElementById('root-loading')
-    if (loadingElement) {
-      loadingElement.style.display = 'none'
-    }
-    if (isConnecting) {
-      setInitialized(true)
-    }
-  }, [isConnecting])
-
-  useEffect(() => {
-    if (!LOGIN_AS_GUEST && ((!isConnected && !isConnecting && initialized) || decentralandConnectStorage === null)) {
+    if ((!isConnected && !isConnecting && hasInitializedConnection) || decentralandConnectStorage === null) {
       window.location.replace(getAuthURL())
       return
     }
@@ -70,7 +57,7 @@ export default function Start(props: Props) {
         return
       }
     }
-  }, [isConnected, isConnecting, wallet, initialized, decentralandConnectStorage])
+  }, [isConnected, isConnecting, wallet, hasInitializedConnection, decentralandConnectStorage])
 
   const handleJumpIn = useCallback(() => {
     initializeKernel()
@@ -85,16 +72,16 @@ export default function Start(props: Props) {
   )
 
   useEffect(() => {
-    if (SKIP_SETUP || LOGIN_AS_GUEST) {
+    if (SKIP_SETUP) {
       handleJumpIn()
     }
   }, [handleJumpIn])
 
-  if (SKIP_SETUP || LOGIN_AS_GUEST) {
+  if (SKIP_SETUP) {
     return null
   }
 
-  if (!initialized || isLoadingProfile || isConnecting) {
+  if (!hasInitializedConnection || isLoadingProfile || isConnecting) {
     return (
       <div className="explorer-website-start">
         <Loader active size="massive" />
@@ -151,7 +138,7 @@ export default function Start(props: Props) {
         <Icon name="discord" className="discord-icon" />
         <p className="discord-info">
           <span>Need guidance?</span>
-          <span>Ask the community</span>
+          <span>ASK THE COMMUNITY</span>
         </p>
       </a>
     </div>

--- a/src/components/start/Start.types.ts
+++ b/src/components/start/Start.types.ts
@@ -4,7 +4,14 @@ import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 export type Props = {
   wallet: Wallet | null
   isConnected: boolean
+  hasInitializedConnection: boolean
+  initializeKernel: () => void
   isConnecting: boolean
   isLoadingProfile: boolean
   profile: Profile | null
 }
+
+export type MapStateProps = Pick<
+  Props,
+  'wallet' | 'isConnected' | 'hasInitializedConnection' | 'isConnecting' | 'isLoadingProfile' | 'profile'
+>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import WalletProvider from 'decentraland-dapps/dist/providers/WalletProvider'
+// import WalletProvider from 'decentraland-dapps/dist/providers/WalletProvider'
 import 'semantic-ui-css/semantic.min.css'
 import './index.css'
 import 'semantic-ui-css/components/site.min.css'
@@ -31,9 +31,7 @@ configureKernel(store)
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <WalletProvider>
-        <App />
-      </WalletProvider>
+      <App />
     </Provider>
   </React.StrictMode>,
   document.getElementById('root')!,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-// import WalletProvider from 'decentraland-dapps/dist/providers/WalletProvider'
 import 'semantic-ui-css/semantic.min.css'
 import './index.css'
 import 'semantic-ui-css/components/site.min.css'

--- a/src/integration/kernel.ts
+++ b/src/integration/kernel.ts
@@ -1,24 +1,10 @@
-import { Store } from "redux"
-import { StoreType } from "../state/redux"
-import { startKernel } from "../kernel-loader"
-import { callOnce } from "../utils/callOnce"
-
-function fadeoutElement(id: string, callback?: () => void) {
-  const element = document.getElementById(id)
-  if (element) {
-    element.style.opacity = '0'
-    setTimeout(() => {
-      element.style.display = 'none'
-      if (callback) {
-        callback()
-      }
-    }, 300)
-  }
-}
+import { Store } from 'redux'
+import { StoreType } from '../state/redux'
+import { startKernel } from '../kernel-loader'
+import { callOnce } from '../utils/callOnce'
 
 export const initializeKernel = callOnce(() => {
   startKernel()
-  fadeoutElement('root-loading')
 })
 
 export function configureKernel(store: Store<StoreType>) {
@@ -26,7 +12,7 @@ export function configureKernel(store: Store<StoreType>) {
 }
 
 let ROOT_HIDDEN = false
-function hideRoot (state: StoreType) {
+function hideRoot(state: StoreType) {
   const sessionReady = !!state.session?.ready
   const rendererReady = !!state.renderer?.ready
   const error = !!state.error?.error


### PR DESCRIPTION
This PR does the following:
- Removes the root loader which contained an older image of the site
- Moves the `AuthProvider` component closer to the `Start` component, making it possible to sign in into the explorer without doing anything with the RPC provider (we were checking something in the provider).
- Changes the way we compute if the connection was initialized at least once.