### PR TITLE
fix: Get provider for guest and connected wallets

### DIFF
--- a/src/components/warning/NetworkWarning.tsx
+++ b/src/components/warning/NetworkWarning.tsx
@@ -12,7 +12,7 @@ export const NetworkWarning: React.FC<NetworkWarningProps> = ({ onClose }) => (
     </div>
     <div className="network-warning-description">
       Blockchain transactions in this network have a cost and real consequences. We recommend you use the{' '}
-      <strong>Sepolia</strong> or <strong>Goerli</strong> test networks instead.
+      <strong>Sepolia</strong> test network instead.
     </div>
     <button className="network-warning-button" onClick={onClose}>
       ⨯

--- a/src/eth/provider.ts
+++ b/src/eth/provider.ts
@@ -10,9 +10,8 @@ export const SECONDS_IN_MILLIS = 1000
 export const CONNECTION_TIMEOUT_IN_MILLIS = 10 * SECONDS_IN_MILLIS
 
 export const chainIdRpc = new Map<number, string>([
-  [1, 'wss://rpc.decentraland.org/mainnet'],
-  [5, 'wss://rpc.decentraland.org/goerli'],
-  [11155111, 'wss://rpc.decentraland.org/sepolia']
+  [ChainId.ETHEREUM_MAINNET, 'wss://rpc.decentraland.org/mainnet'],
+  [ChainId.ETHEREUM_SEPOLIA, 'wss://rpc.decentraland.org/sepolia']
 ])
 
 export async function getEthereumProvider(
@@ -31,6 +30,10 @@ export async function getEthereumProvider(
       chainId,
       account: null
     }
+  }
+
+  if (connection.isConnected()) {
+    return connection.tryPreviousConnection()
   }
 
   const result = await connection.connect(type, chainId)


### PR DESCRIPTION
This PR fixes the `authenticate` logic of a guest connection.

When passing a `ProviderType === null,` a new provider connection should be created using the decentraland RPCs.