### PR TITLE
fix: add '?' to deep link

### DIFF
--- a/src/integration/desktop.ts
+++ b/src/integration/desktop.ts
@@ -89,7 +89,7 @@ export const launchDesktopApp = async (force = false) => {
     customProtocolParams.push(`realm=${data.realm}`)
   }
 
-  const customProtocolTarget = `decentraland://${customProtocolParams.join('&')}`
+  const customProtocolTarget = `decentraland://?${customProtocolParams.join('&')}`
 
   // assume that the desktop version is installed only if
   // we detect a loss of focus on window


### PR DESCRIPTION
Add a `?` at the beginning of the deep link