### PR TITLE
feat: Add new E@ launch parameters

### DIFF
--- a/src/integration/analytics.ts
+++ b/src/integration/analytics.ts
@@ -5,7 +5,7 @@ import { store } from '../state/redux'
 import { getRequiredAnalyticsContext } from '../state/selectors'
 import { errorToString } from '../utils/errorToString'
 import { getRepositoryName, getRepositoryVersion, track } from '../utils/tracking'
-import { getCurrentPosition } from './browser'
+import { getExplorerLaunchParameters } from './browser'
 import { DEBUG_ANALYTICS, PLATFORM, RENDERER_TYPE } from './url'
 
 let analyticsDisabled = false
@@ -42,7 +42,7 @@ export function configureSegment() {
 }
 
 function injectTrackingMetadata(payload: Record<string, any>): void {
-  Object.assign(payload, getCurrentPosition())
+  Object.assign(payload, getExplorerLaunchParameters())
   payload.dcl_is_authenticated = authFlags.isAuthenticated
   payload.dcl_is_guest = authFlags.isGuest
   payload.dcl_disabled_analytics = authFlags.afterFatalError

--- a/src/integration/browser.ts
+++ b/src/integration/browser.ts
@@ -104,23 +104,36 @@ export function isMacOS() {
   return false
 }
 
-export type UserPosition = Partial<{
-  realm: string
-  position: string
+export type ExplorerLaunchParameters = Partial<{
+  realm: string | undefined
+  position: string | undefined
+  'self-preview-builder-collections': string | undefined
+  dclenv: string | undefined
 }>
 
-export function getCurrentPosition() {
-  const data: UserPosition = {}
+export function getExplorerLaunchParameters() {
+  const data: ExplorerLaunchParameters = {}
   const qs = new URLSearchParams(globalThis.location.search || '')
 
-  // inject realm
-  if (qs.has('realm')) {
-    data.realm = qs.get('realm')!
+  const realm = qs.get('realm')
+  const position = qs.get('position')
+  const selfPreviewBuilderCollections = qs.get('self-preview-builder-collections')
+  const dclenv = qs.get('dclenv')
+
+  if (realm) {
+    data.realm = realm
   }
 
-  // inject position
-  if (qs.has('position')) {
-    data.position = qs.get('position')!
+  if (position) {
+    data.position = position
+  }
+
+  if (selfPreviewBuilderCollections) {
+    data['self-preview-builder-collections'] = selfPreviewBuilderCollections
+  }
+
+  if (dclenv) {
+    data.dclenv = dclenv
   }
 
   return data

--- a/src/integration/desktop.ts
+++ b/src/integration/desktop.ts
@@ -1,7 +1,7 @@
 import { setDownloadNewVersion, setDownloadProgress, setDownloadReady, setKernelError } from '../state/actions'
 import { store } from '../state/redux'
 import { callOnce } from '../utils/callOnce'
-import { getCurrentPosition, hasRecentlyLoggedIn, isMobile } from './browser'
+import { getExplorerLaunchParameters, hasRecentlyLoggedIn, isMobile } from './browser'
 import { SKIP_SETUP } from './url'
 
 export const isElectron = callOnce((): boolean => {
@@ -79,15 +79,8 @@ export const launchDesktopApp = async (force = false) => {
   }
 
   // build custom protocol target using current url `position` and `realm`
-  const data = getCurrentPosition()
-  let customProtocolParams: string[] = []
-  if (data.position) {
-    customProtocolParams.push(`position=${data.position}`)
-  }
-
-  if (data.realm) {
-    customProtocolParams.push(`realm=${data.realm}`)
-  }
+  const data = getExplorerLaunchParameters()
+  let customProtocolParams: string[] = Object.entries(data).map(([key, value]) => `${key}=${value}`)
 
   const customProtocolTarget = `decentraland://?${customProtocolParams.join('&')}`
 


### PR DESCRIPTION
This PR adds two new deep link parameters to the explorer launch action:
- self-preview-builder-collections: which allows users to test their builder collections on the E@.
- dclenv: which allows users to start the E@ using different environments.