### PR TITLE
fix: disable production sourcemaps to unblock CI publish

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -113,7 +113,12 @@ export default defineConfig(({ command, mode }) => {
             rollupOptions: {
               plugins: [rollupNodePolyFill()]
             },
-            sourcemap: true
+            // Sourcemaps were doubling the publish tarball (one .map per chunk) and the wallet
+            // stack added thousands of chunks — the GitHub Actions runner was killed mid-`npm
+            // publish` while emitting the per-file `npm notice` listing. Disabling regenerates a
+            // smaller, publishable dist. Re-enable as 'hidden' if Sentry source-map upload is
+            // wired up later (would need a separate strip-from-publish step).
+            sourcemap: false
           }
         }
       : undefined)


### PR DESCRIPTION
## What

Sets `build.sourcemap: false` in `vite.config.ts` (was `true`).

## Why

After #484 merged, the publish step on `main` was hard-killed mid-`npm publish` with no error trailer — the last log line was `npm notice 2.0k` while the runner was iterating through every published asset in `npm notice Tarball Contents`. Either an OOM or the GitHub Actions step-output size limit.

The wallet stack we picked up in #484 (`decentraland-connect@12` + `decentraland-dapps@28` → reown / wagmi / walletconnect / viem / etc) emits hundreds of small vendor chunks. With `sourcemap: true`, **every chunk got a `.map` sibling**, roughly doubling file count and tarball size. The `oddish-action` publish runs `npm publish --provenance` from `./dist`, and at that file count the per-file `npm notice` listing alone overflowed whatever runner limit killed the step.

## How

Single-line change. Measured locally on `Node 24.11.1` / `Vite 7.3.3`:

| Metric | Before (sourcemap: true) | After (sourcemap: false) |
|---|---|---|
| `dist/` size | ~50+ MB | **27 MB** |
| Total files in dist | ~2700+ | **1359** |
| `.map` files | ~1350+ | **0** |
| `npm run build` time | ~53s | **35s** |

Build still succeeds end-to-end. The main chunk is still ~4.85 MB minified / 1.16 MB gzipped — sourcemaps were not the cause of bundle bloat, just doubling the *publish* payload.

## Follow-ups (out of scope)

- If/when Sentry source-map upload is wired up, switch to `sourcemap: 'hidden'` (still generated in `dist/`, no `//# sourceMappingURL=` comment in chunks) **and** add a strip-from-publish step (e.g. delete `dist/**/*.map` before `oddish-action` runs, or move them to a separate Sentry-only artifact). Hidden maps alone wouldn't fix this — they still inflate the publish tarball.
- The bigger lever is screen-level `React.lazy` for the wallet/Start path so most of those vendor chunks aren't even in the entry. That's a bigger PR.

## Test plan

- [ ] `npm run build` on Node 24 succeeds (verified locally).
- [ ] CI publish on this branch / after merge to `main` completes (the actual blocker).
- [ ] No `.map` files in `dist/assets/`.