### PR TITLE
fix: disable npm provenance in oddish-action publish step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,13 @@ jobs:
           cwd: ./dist
           ## use action runId instead of current date to generate snapshot numbers
           deterministic-snapshot: true
+          ## npm 11 (shipped with Node 24) emits `EUSAGE: Automatic provenance generation not
+          ## supported for provider: null` when invoked from inside oddish-action's spawn — the
+          ## OIDC provider detection no longer recognises the environment. Disable until either
+          ## oddish-action is updated or the OIDC plumbing is fixed upstream. Provenance is a
+          ## SLSA attestation; explorer-website is consumed as a CDN bundle, not as a
+          ## library, so we don't lose anything observable by turning it off here.
+          provenance: 'false'
           ## inform gitlab after publishing to proceed with CDN propagation
           gitlab-token: ${{ secrets.GITLAB_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_URL }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -113,7 +113,12 @@ export default defineConfig(({ command, mode }) => {
             rollupOptions: {
               plugins: [rollupNodePolyFill()]
             },
-            sourcemap: true
+            // Sourcemaps were doubling the publish tarball (one .map per chunk) and the wallet
+            // stack added thousands of chunks — the GitHub Actions runner was killed mid-`npm
+            // publish` while emitting the per-file `npm notice` listing. Disabling regenerates a
+            // smaller, publishable dist. Re-enable as 'hidden' if Sentry source-map upload is
+            // wired up later (would need a separate strip-from-publish step).
+            sourcemap: false
           }
         }
       : undefined)


### PR DESCRIPTION
## What

Sets `provenance: 'false'` on the `decentraland/oddish-action@master` step in `.github/workflows/main.yml`.

## Why

After #485 unblocked the sourcemap/size issue (publish step now reaches the registry call), CI on `main` failed with:

```
npm notice total files: 1355
npm notice Publishing to https://registry.npmjs.org/ with tag next and public access
npm error code EUSAGE
npm error Automatic provenance generation not supported for provider: null
```

npm 11 (shipped with Node 24, which we bumped to in #484) tightened its CI-provider detection for `--provenance`. When invoked from inside `oddish-action`'s child-process spawn, npm 11 can no longer identify the GitHub Actions environment and returns `provider: null` instead of `github-actions`, so it refuses to attest.

Provenance was succeeding on `main` previously (`2.5.1-...-commit-3983fe4` published cleanly) — the regression is specifically from the npm 10 → 11 jump that came along with the Node 20 → 24 bump.

## How

`oddish-action`'s `action.yml` exposes a `provenance` input that defaults to `'true'`. Setting it to `'false'` makes the action invoke `npm publish` without the `--provenance` flag, sidestepping the broken detection.

## Trade-off

Provenance is a SLSA attestation cryptographically tying a published tarball back to a specific CI workflow + commit. It's optional and primarily meaningful when the package is consumed as a library so downstream installs can verify origin. `explorer-website` is consumed as a CDN bundle (via the `dist/` artifact), not as a library install — so disabling provenance has no observable consumer impact here.

## Follow-up (out of scope)

The proper upstream fix would be either:
- Updating `oddish-action` to plumb the OIDC env (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) through to the npm 11 child process, **or**
- Pinning npm to a version (10.x) where automatic detection from inside a wrapper still works.

Either is a bigger change with maintainer involvement; this PR is the minimal unblock.

## Test plan

- [ ] CI on `main` after merge completes the publish step (the actual blocker).
- [ ] Resulting `next`-tagged package is reachable on `npmjs.org` (just no provenance attestation).