### PR TITLE
fix: point CDN propagation trigger at new GitLab deployer secrets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           ## library, so we don't lose anything observable by turning it off here.
           provenance: 'false'
           ## inform gitlab after publishing to proceed with CDN propagation
-          gitlab-token: ${{ secrets.GITLAB_TOKEN }}
-          gitlab-pipeline-url: ${{ secrets.GITLAB_URL }}
+          gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
+          gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Swaps the two secrets oddish-action uses to trigger the CDN-propagation pipeline:

```yaml
- gitlab-token: ${{ secrets.GITLAB_TOKEN }}
- gitlab-pipeline-url: ${{ secrets.GITLAB_URL }}
+ gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
+ gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
```

## Why

After #485 (sourcemap) and #486 (provenance) unblocked `npm publish`, the workflow then started failing on the post-publish step that pings GitLab to propagate the CDN bundle:

```
##[group]Triggering external pipeline
##[error]Error triggering pipeline. status: 400
```

`npm publish` itself succeeded — `2.6.1-25865517797.commit-b7a7cba` is live on the registry tagged `next`. The 400 was coming from the GitLab `/api/v4/projects/.../trigger/pipeline` call. The old `GITLAB_TOKEN` / `GITLAB_URL` secrets pointed at a stale pipeline (the deployer moved, and oddish-action's hardcoded `ref: "master"` no longer resolved on the target project). The replacement `GITLAB_CDN_DEPLOYER_TOKEN` / `GITLAB_CDN_DEPLOYER_URL` secrets point at the current CDN deployer.

## Test plan

- [ ] After merge, the workflow's "publish npm package" step completes through both phases (npm publish + GitLab trigger).
- [ ] The triggered GitLab pipeline runs and propagates the published `next`-tagged tarball to the CDN.